### PR TITLE
fix: document click 핸들러가 basepath 밖 경로도 가로채던 문제

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `RouterConfig.externalPrefixes` — 이 라우터의 관할 밖으로 취급할 경로 접두사 목록. 동일 origin에 여러 SPA가 서로 다른 경로 아래에 병렬 배포된 상황에서, 형제 SPA 경로로 향하는 앵커 클릭이 현재 라우터의 fallback으로 흘러 들어가는 것을 막습니다.
+
+### Fixed
+- Document-level click 핸들러가 라우터의 `basepath` 밖 same-origin 경로까지 가로채 fallback을 렌더하던 문제 수정. 이제 `basepath`가 `/`가 아닐 때 `basepath` 밖 경로는 자동으로 브라우저 네비게이션에 위임되며, `basepath: '/'`는 `externalPrefixes`로 형제 SPA 경로를 명시할 수 있습니다. `<u-link>`가 이미 수행하던 경계 검사와 동작이 일관되게 정렬됩니다.
+
 ## [0.9.2] - 2026-04-13
 
 ### Fixed

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -21,6 +21,7 @@ export class Router {
   private readonly _routes: RouteConfig[];
   private readonly _fallback?: FallbackRouteConfig;
   private readonly _enter?: RouterConfig['enter'];
+  private readonly _externalPrefixes: string[];
   private readonly _tracker = new RouteTracker();
 
   /** 현재 라우팅 요청 ID */
@@ -36,6 +37,9 @@ export class Router {
     this._routes = setRoutes(config.routes || [], this._basepath);
     this._fallback = config.fallback;
     this._enter = config.enter;
+    this._externalPrefixes = (config.externalPrefixes ?? [])
+      .map((p) => p.replace(/\/+$/, ''))
+      .filter((p) => p.length > 0);
     window.addEventListener('popstate', this.handleWindowPopstate);
 
     if (config.useIntercept !== false) {
@@ -218,10 +222,33 @@ export class Router {
       if (anchor.getAttribute('rel') === 'external') return;
       if (anchor.target && anchor.target !== '') return;
 
+      // 이 라우터의 관할 밖으로 향하는 same-origin 앵커는 가로채지 않고
+      // 브라우저 기본 네비게이션(전체 페이지 로드)에 위임합니다.
+      // - basepath가 '/'가 아니면 basepath 밖 경로는 자동으로 외부 취급.
+      // - basepath가 '/'인 경우 `externalPrefixes`로 형제 SPA의 경로를
+      //   명시해야 외부 취급됩니다.
+      const targetPathname = new URL(anchor.href, window.location.origin).pathname;
+      if (this._isOutsideScope(targetPathname)) return;
+
       e.preventDefault();
       await this.go(anchor.href);
     } catch {
       // 예외는 무시하고 기본 동작 유지
     }
   };
+
+  /** 주어진 경로가 이 라우터의 관할 밖인지 판단합니다. */
+  private _isOutsideScope(pathname: string): boolean {
+    if (this._basepath !== '/' && !this._isWithin(pathname, this._basepath)) {
+      return true;
+    }
+    for (const prefix of this._externalPrefixes) {
+      if (this._isWithin(pathname, prefix)) return true;
+    }
+    return false;
+  }
+
+  private _isWithin(pathname: string, prefix: string): boolean {
+    return pathname === prefix || pathname.startsWith(prefix + '/');
+  }
 }

--- a/src/types/RouterConfig.ts
+++ b/src/types/RouterConfig.ts
@@ -52,6 +52,31 @@ export interface RouterConfig {
   useIntercept?: boolean;
 
   /**
+   * 이 라우터의 관할 밖으로 취급할 경로 접두사 목록입니다.
+   * 동일 origin에 여러 SPA가 서로 다른 경로 아래에 나란히 배포된 상황에서,
+   * 현재 SPA가 본인 라우트가 아닌 형제 SPA로 향하는 앵커 클릭을 가로채어
+   * fallback으로 흘려 보내는 문제를 방지합니다.
+   *
+   * - 여기 나열된 prefix로 시작하는 href 클릭은 가로채지 않고 브라우저 기본
+   *   네비게이션에 위임합니다 (전체 페이지 로드).
+   * - `basepath`가 `/`가 아닌 경우에는 `basepath` 밖의 경로는 별도 설정 없이
+   *   자동으로 외부 취급됩니다. 이 옵션은 `basepath: '/'`로 마운트된 SPA가
+   *   동일 호스트의 다른 SPA 경로를 명시적으로 지정할 때 유용합니다.
+   *
+   * @example
+   * ```typescript
+   * // 포털 SPA가 `/`에 마운트되어 있고, 같은 호스트에 `/admin`, `/docs`가
+   * // 별개 SPA로 배포된 경우
+   * new Router({
+   *   basepath: '/',
+   *   routes: portalRoutes,
+   *   externalPrefixes: ['/admin', '/docs'],
+   * });
+   * ```
+   */
+  externalPrefixes?: string[];
+
+  /**
    * 초기 로드 시 현재 URL로 라우팅을 자동으로 수행할지 여부를 설정합니다.
    * @default true
    */


### PR DESCRIPTION
## 문제

`Router`의 document-level click 핸들러는 same-origin 앵커 클릭을 무조건 가로채 `router.go(href)`로 처리한다. 이 때문에 같은 호스트 아래에 서로 다른 경로로 여러 SPA가 병렬 배포된 환경에서 형제 SPA로 향하는 링크 클릭이 현재 라우터의 fallback으로 흘러 들어가 soft-404를 렌더한다. URL 바만 바뀌고 실제 대상 SPA의 JS는 로드되지 않는다.

`<u-link>` 컴포넌트는 이미 basepath 경계 검사를 수행하므로(`src/components/ULink.ts`) `<u-link>` 기반 링크는 정상 동작하지만, 소비자가 평문 `<a>` 태그를 사용하는 순간 이 비일관성이 드러난다.

### 관련 코드 (수정 전)

`src/Router.ts:handleDocumentClick`

```ts
if (isExternalUrl(href)) return;      // cross-origin만 검사
if (anchor.hasAttribute('download')) return;
if (anchor.getAttribute('rel') === 'external') return;
if (anchor.target && anchor.target !== '') return;

e.preventDefault();
await this.go(anchor.href);            // 이 라우터의 관할 밖 경로도 포함
```

`src/components/ULink.ts`의 `<u-link>`는 이 검사를 이미 가지고 있음:

```ts
if (this.href.startsWith('/')) {
  if (!this.href.startsWith(basepath)) {
    window.location.assign(this.href); // 풀 리로드
    return;
  }
  this.dispatchPopstate(basepath, this.href);
  return;
}
```

## 재현

```ts
new Router({
  root: document.body,
  basepath: '/admin',
  routes: adminRoutes,
});
```

위 라우터가 마운트된 상태에서:

```html
<a href=\"/docs/getting-started\">Docs</a>
```

를 클릭하면:

- **Before**: 라우터가 가로채 `router.go('/docs/getting-started')` 호출. `/docs/*`에 매치되는 라우트가 없으므로 fallback이 렌더되고 URL 바만 변경(soft-404). `/docs`에 배포된 별개 SPA는 절대 부팅되지 않음.
- **After**: 라우터가 개입하지 않고 브라우저가 `/docs/getting-started`로 전체 페이지 로드. 대상 SPA가 정상 부팅.

## 수정 내용

1. `basepath`가 `/`가 아닐 때, 앵커의 pathname이 `basepath`로 시작하지 않으면 라우터가 개입하지 않고 브라우저 기본 네비게이션에 위임한다. **추가 설정 없이 자동 적용.**
2. `basepath: '/'`로 루트에 마운트된 라우터는 모든 경로가 `/`로 시작하므로 경계를 추론할 수 없다. 이 경우를 위해 `RouterConfig.externalPrefixes?: string[]` 옵션을 추가했다. 여기 나열된 prefix로 향하는 클릭은 가로채지 않는다.

```ts
new Router({
  root: document.body,
  basepath: '/',
  routes: rootRoutes,
  externalPrefixes: ['/admin', '/docs'],
});
```

`/admin/*`, `/docs/*` 클릭은 브라우저 네비게이션으로 위임. 그 외 unknown 경로는 기존처럼 fallback(지정 시)이 렌더된다.

### 경계 판정

- `pathname === prefix` 또는 `pathname.startsWith(prefix + '/')` 인 경우 prefix의 하위로 간주.
- `/administrator`는 `/admin`의 하위가 아니라 별개 경로 (prefix의 부분 일치 방지).
- `externalPrefixes`는 후행 슬래시를 허용하며 내부적으로 정규화 (`'/admin/'` → `'/admin'`).

## 하위 호환성

- `basepath: '/'` + `externalPrefixes` 미지정 = 기존 동작 100% 유지.
- `basepath` 비-루트인 경우의 passthrough는 이번 PR로 즉시 활성화되지만, 이는 그동안 fallback 소프트-404로 위장되어 있었던 **실제 버그 수정**에 해당한다. Fallback이 이 경로에 대해 의도적으로 렌더되고 있었다면 해당 컨슈머는 링크가 잘못 연결되어 있었을 가능성이 높다.

## 변경 파일

- `src/Router.ts` — `_externalPrefixes` 저장, `handleDocumentClick`에서 scope 검사 추가, `_isOutsideScope`/`_isWithin` 헬퍼
- `src/types/RouterConfig.ts` — `externalPrefixes` 옵션 문서화
- `CHANGELOG.md` — Unreleased 섹션 추가

## Test plan

- [ ] 기존 빌드(`pnpm build`) 통과 확인
- [ ] `basepath: '/admin'`로 마운트된 상태에서 `/docs/...` 앵커 클릭 시 브라우저 전체 로드로 위임되는지 수동 검증
- [ ] `basepath: '/'`, `externalPrefixes: ['/admin']` 설정 후 `/admin/...` 클릭이 위임되고 `/` `/users` 같은 내부 경로는 기존대로 SPA 라우팅되는지 수동 검증
- [ ] `<u-link>`를 사용하는 기존 통합은 영향 없음 확인 (`u-link`는 이미 자체 basepath 검사)
- [ ] `rel=\"external\"`, `target`, `download`, modifier key 등 기존 skip 조건이 변함없이 동작하는지 확인